### PR TITLE
feat: add support separately included authors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webmention-handler",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "A handler for web mentions",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/classes/web-mention-handler.class.ts
+++ b/src/classes/web-mention-handler.class.ts
@@ -1,3 +1,4 @@
+import { normalizeAuthors } from "../functions/normalize-authors.function";
 import { convertHEntryToMention } from "../functions/convert-h-entry-to-mention";
 import { fetchHtml } from "../functions/fetch-html.function";
 import { isUrl } from "../functions/is-url.function";
@@ -96,6 +97,13 @@ export class WebMentionHandler implements IWebMentionHandler{
     // If the page does not include any mention of the target, then we can return
     // early as we have already deleted any stored mentions with this target and source
     if(!mentionedUrls) return null;
+
+    // Not every post has an author, some pages also have authors on a
+    // seperate page, as such we should normalize it a local author if possible
+    await Promise.all(hEntries.map(async (entry, index) => {
+      if(!entry.author) return;
+      hEntries[index].author = await normalizeAuthors(entry);
+    }))
 
     let mentions = hEntries.map(h => convertHEntryToMention(h, mention.source, mention.target));
     // if there are only basic mentions, use the first (most complete mention)

--- a/src/functions/get-external-author.function.test.ts
+++ b/src/functions/get-external-author.function.test.ts
@@ -1,15 +1,30 @@
+import path from "path";
+import fs from "fs";
 import { getExternalAuthor } from "./get-external-author.function";
+
 let fetchMock:jest.SpyInstance;
 describe('getExternalAuthor', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     fetchMock = jest.spyOn(require('./fetch-html.function'), 'fetchHtml').mockImplementation((url) => {
-      if(url === 'https://example.org') return {status: 200, html: `<html><body><div class="h-card"><img class="u-photo" src="https://example.org/images/mike.png" alt="Michael Walter Van Der Velden"><h1><a href="/" class="u-url p-name">Michael Walter Van Der Velden</a></h1></div></body></html>`};
+      if(url === 'https://example.org') return {
+        status: 200,
+        html: fs.readFileSync(path.join(__dirname, '../test-data/html-author.html'), 'utf8')
+    };
       return {error: '404'};
     });
-  })
+  });
   it('fetches an author correctly', async () => {
     const author = await getExternalAuthor('https://example.org');
-    const expected = {"name": "Michael Walter Van Der Velden", "photo": {"alt": "Michael Walter Van Der Velden", "value": "https://example.org/images/mike.png"}, "url": "https://example.org/", "type": "h-card"};
+    const expected = {
+      "name": "Michael Walter Van Der Velden",
+      "photo": {
+        "alt": "Michael Walter Van Der Velden",
+        "value": "https://example.org/images/mike.png"
+      },
+      "url": "https://example.org/",
+      "type": "h-card"
+    };
     expect(author).toEqual(expected);
     expect(fetchMock).toHaveBeenCalledWith('https://example.org');
   });

--- a/src/functions/get-external-author.function.test.ts
+++ b/src/functions/get-external-author.function.test.ts
@@ -1,0 +1,16 @@
+import { getExternalAuthor } from "./get-external-author.function";
+let fetchMock:jest.SpyInstance;
+describe('getExternalAuthor', () => {
+  beforeEach(() => {
+    fetchMock = jest.spyOn(require('./fetch-html.function'), 'fetchHtml').mockImplementation((url) => {
+      if(url === 'https://example.org') return {status: 200, html: `<html><body><div class="h-card"><img class="u-photo" src="https://example.org/images/mike.png" alt="Michael Walter Van Der Velden"><h1><a href="/" class="u-url p-name">Michael Walter Van Der Velden</a></h1></div></body></html>`};
+      return {error: '404'};
+    });
+  })
+  it('fetches an author correctly', async () => {
+    const author = await getExternalAuthor('https://example.org');
+    const expected = {"name": "Michael Walter Van Der Velden", "photo": {"alt": "Michael Walter Van Der Velden", "value": "https://example.org/images/mike.png"}, "url": "https://example.org/", "type": "h-card"};
+    expect(author).toEqual(expected);
+    expect(fetchMock).toHaveBeenCalledWith('https://example.org');
+  });
+})

--- a/src/functions/get-external-author.function.ts
+++ b/src/functions/get-external-author.function.ts
@@ -1,0 +1,15 @@
+import { fetchHtml } from "./fetch-html.function";
+import { parse as htmlParser } from 'node-html-parser';
+import { mf2 } from "microformats-parser";
+import { normalizeEntry } from "./normalize-entry.function";
+
+export async function getExternalAuthor(url: string): Promise<any> {
+  const {html} = await fetchHtml(url);
+  if(!html) return false;
+  const dom = htmlParser(html);
+  const card = dom.querySelector('.h-card');
+  if(!card) return false;
+  const mf = mf2(card.toString(), { baseUrl: url}).items as any[];
+  if(!mf.length) return false;
+  return normalizeEntry(mf[0]);
+}

--- a/src/functions/normalize-authors.function.test.ts
+++ b/src/functions/normalize-authors.function.test.ts
@@ -1,0 +1,44 @@
+import { normalizeAuthors } from "./normalize-authors.function";
+
+let fetchMock:jest.SpyInstance;
+describe('normalizeAuthors', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetchMock = jest.spyOn(require('./fetch-html.function'), 'fetchHtml').mockImplementation((url) => {
+      if(url === 'https://example.org') return {status: 200, html: `<html><body><div class="h-card"><img class="u-photo" src="https://example.org/images/mike.png" alt="Michael Walter Van Der Velden"><h1><a href="/" class="u-url p-name">Michael Walter Van Der Velden</a></h1></div></body></html>`};
+      return {error: '404'};
+    });
+  });
+
+  it('correctly handles a single author', async () => {
+    const authors = await normalizeAuthors('https://example.org');
+    const expected = {"name": "Michael Walter Van Der Velden", "photo": {"alt": "Michael Walter Van Der Velden", "value": "https://example.org/images/mike.png"}, "url": "https://example.org/", "type": "h-card"};
+    expect(authors).toEqual(expected);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith('https://example.org');
+  });
+
+  it('correctly handles multiple authors', async () => {
+    const authors = await normalizeAuthors(['https://example.org', 'https://example.org']);
+    const expected = {"name": "Michael Walter Van Der Velden", "photo": {"alt": "Michael Walter Van Der Velden", "value": "https://example.org/images/mike.png"}, "url": "https://example.org/", "type": "h-card"};
+    expect(authors).toEqual([expected, expected]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledWith('https://example.org');
+  });
+
+  it('correctly handles multiple authors where one is invalid', async () => {
+    const authors = await normalizeAuthors(['https://example.org', 'https://example.com']);
+    const expected = {"name": "Michael Walter Van Der Velden", "photo": {"alt": "Michael Walter Van Der Velden", "value": "https://example.org/images/mike.png"}, "url": "https://example.org/", "type": "h-card"};
+    expect(authors).toEqual([expected, 'https://example.com']);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledWith('https://example.org');
+    expect(fetchMock).toHaveBeenCalledWith('https://example.com');
+  });
+
+  it('correctly handles an already normalized author', async () => {
+    const expected = {"name": "Michael Walter Van Der Velden", "photo": {"alt": "Michael Walter Van Der Velden", "value": "https://example.org/images/mike.png"}, "url": "https://example.org/", "type": "h-card"};
+    const authors = await normalizeAuthors(expected);
+    expect(authors).toEqual(expected);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/functions/normalize-authors.function.test.ts
+++ b/src/functions/normalize-authors.function.test.ts
@@ -1,44 +1,55 @@
+import path from "path";
+import fs from "fs";
 import { normalizeAuthors } from "./normalize-authors.function";
 
 let fetchMock:jest.SpyInstance;
+const exampleJSON = {
+  "name": "Michael Walter Van Der Velden",
+  "photo": {
+    "alt": "Michael Walter Van Der Velden",
+    "value": "https://example.org/images/mike.png"
+  },
+  "url": "https://example.org/",
+  "type": "h-card"
+};
+
 describe('normalizeAuthors', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     fetchMock = jest.spyOn(require('./fetch-html.function'), 'fetchHtml').mockImplementation((url) => {
-      if(url === 'https://example.org') return {status: 200, html: `<html><body><div class="h-card"><img class="u-photo" src="https://example.org/images/mike.png" alt="Michael Walter Van Der Velden"><h1><a href="/" class="u-url p-name">Michael Walter Van Der Velden</a></h1></div></body></html>`};
+      if(url === 'https://example.org') return {
+        status: 200,
+        html: fs.readFileSync(path.join(__dirname, '../test-data/html-author.html'), 'utf8')
+    };
       return {error: '404'};
     });
   });
 
   it('correctly handles a single author', async () => {
     const authors = await normalizeAuthors('https://example.org');
-    const expected = {"name": "Michael Walter Van Der Velden", "photo": {"alt": "Michael Walter Van Der Velden", "value": "https://example.org/images/mike.png"}, "url": "https://example.org/", "type": "h-card"};
-    expect(authors).toEqual(expected);
+    expect(authors).toEqual(exampleJSON);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith('https://example.org');
   });
 
   it('correctly handles multiple authors', async () => {
     const authors = await normalizeAuthors(['https://example.org', 'https://example.org']);
-    const expected = {"name": "Michael Walter Van Der Velden", "photo": {"alt": "Michael Walter Van Der Velden", "value": "https://example.org/images/mike.png"}, "url": "https://example.org/", "type": "h-card"};
-    expect(authors).toEqual([expected, expected]);
+    expect(authors).toEqual([exampleJSON, exampleJSON]);
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock).toHaveBeenCalledWith('https://example.org');
   });
 
   it('correctly handles multiple authors where one is invalid', async () => {
     const authors = await normalizeAuthors(['https://example.org', 'https://example.com']);
-    const expected = {"name": "Michael Walter Van Der Velden", "photo": {"alt": "Michael Walter Van Der Velden", "value": "https://example.org/images/mike.png"}, "url": "https://example.org/", "type": "h-card"};
-    expect(authors).toEqual([expected, 'https://example.com']);
+    expect(authors).toEqual([exampleJSON, 'https://example.com']);
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock).toHaveBeenCalledWith('https://example.org');
     expect(fetchMock).toHaveBeenCalledWith('https://example.com');
   });
 
   it('correctly handles an already normalized author', async () => {
-    const expected = {"name": "Michael Walter Van Der Velden", "photo": {"alt": "Michael Walter Van Der Velden", "value": "https://example.org/images/mike.png"}, "url": "https://example.org/", "type": "h-card"};
-    const authors = await normalizeAuthors(expected);
-    expect(authors).toEqual(expected);
+    const authors = await normalizeAuthors(exampleJSON);
+    expect(authors).toEqual(exampleJSON);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/src/functions/normalize-authors.function.ts
+++ b/src/functions/normalize-authors.function.ts
@@ -1,0 +1,12 @@
+import { getExternalAuthor } from "./get-external-author.function";
+
+export async function normalizeAuthors(potentialAuthors: any | any[]): Promise<any | any[]> {
+  if(!potentialAuthors) return;
+  const authors = Array.isArray(potentialAuthors) ? potentialAuthors : [potentialAuthors];
+  const authorList = await Promise.all(authors.map(async (a: any) => {
+    if(typeof a !== "string") return a;
+    const author = await getExternalAuthor(a);
+    return author || a; // If the page doesn't have an author object on it, then the url is better than nothing
+  }));
+  return authorList.length > 1 ? authorList : authorList[0];
+}

--- a/src/functions/normalize-entry.function.test.ts
+++ b/src/functions/normalize-entry.function.test.ts
@@ -8,13 +8,13 @@ describe('normalizeEntry', () => {
         'url': 'https://example.com'
       },
       'contributer': ['example'],
-      'like-of': 'https://mikevdv.dev/blog/2022-07-05-web-mentions'
+      'like-of': 'https://example.org/blog/2022-07-05-web-mentions'
     }
     const flat = {
       'name': 'dave',
       'contributer': 'example',
       'url': 'https://example.com',
-      'like-of': 'https://mikevdv.dev/blog/2022-07-05-web-mentions'
+      'like-of': 'https://example.org/blog/2022-07-05-web-mentions'
     };
     expect(normalizeEntry(entry)).toEqual(flat);
   });
@@ -43,7 +43,7 @@ describe('normalizeEntry', () => {
         }],
         url: 'example.com/path'
       },
-      'like-of': 'https://mikevdv.dev/blog/2022-07-05-web-mentions'
+      'like-of': 'https://example.org/blog/2022-07-05-web-mentions'
     }
     const normal = {
       "contributer": {
@@ -53,7 +53,7 @@ describe('normalizeEntry', () => {
           "http://example.com/dave",
         ],
       },
-      "like-of": "https://mikevdv.dev/blog/2022-07-05-web-mentions",
+      "like-of": "https://example.org/blog/2022-07-05-web-mentions",
       "url": "example.com/path",
     };
     expect(normalizeEntry(entry)).toEqual(normal);

--- a/src/functions/parse-html.function.ts
+++ b/src/functions/parse-html.function.ts
@@ -4,7 +4,7 @@ import { getHEntries } from "./get-h-entries.function";
 import { getHtmlLinks } from "./get-html-links.function";
 import { normalizeEntry } from './normalize-entry.function';
 
-export function parseHtml(html: string, source: string, target: string): MicroformatRoot[] {
+export function parseHtml(html: string, source: string, target: string): any[] {
   const dom = htmlParser(html);
   const urls = getHtmlLinks(dom);
   const items = getHEntries(dom, source, target);

--- a/src/test-data/html-author.html
+++ b/src/test-data/html-author.html
@@ -1,0 +1,8 @@
+<html>
+   <body>
+      <div class="h-card">
+         <img class="u-photo" src="https://example.org/images/mike.png" alt="Michael Walter Van Der Velden">
+         <h1><a href="/" class="u-url p-name">Michael Walter Van Der Velden</a></h1>
+      </div>
+   </body>
+</html>

--- a/src/test-data/html-reply-with-external-author.html
+++ b/src/test-data/html-reply-with-external-author.html
@@ -1,0 +1,10 @@
+<html>
+  <body>
+    <div class="h-entry">
+      <a class="p-author" href="http://mysite.example.org">Supercool Indiewebauthor</a>: 
+      in reply to:
+      <a href="http://example.com/note123" class="u-in-reply-to">Some note with a point</a>
+      <div class="p-name p-content">Good point! Now what is the next thing we should do?</div>
+     </div>
+  </body>
+</html>


### PR DESCRIPTION
Looking at the indie web wiki, it's possible to include author information [on a separate page](https://indieweb.org/authorship#Dedicated_author_page). This seems like a reasonable thing to support and as such this PR adds support for it.