### PR TITLE
chore: change release method

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,28 +1,32 @@
 name: Release Module
 
 on:
-  push:
-    branches:
-      - main
-
-jobs:
   release:
-
+    types: [created]
+jobs:
+  npm:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [16.x]
-  
+    if: contains(github.ref, 'tags')
     steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-      - run: npm ci
-      - run: npm run build
-      - uses: mikeal/merge-release@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+    - uses: actions/checkout@v3
+
+    - name: Use Node.js 16
+      uses: actions/setup-node@v3
+      with:
+        node-version: '16.x'
+
+    - name: Install npm dependencies
+      run: npm ci
+
+    - name: Test and build package
+      run: |
+        npm test
+        npm run build
+    - name: Publish tag to npm
+      run: npm publish --access=public
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+
+    - uses: actions/setup-node@v1
+      with:
+        registry-url: 'https://npm.pkg.github.com'


### PR DESCRIPTION
The previous release method wasn't flexible enough for a pre 1.0.0 project. this slight change to CI workflow should allow for an improved ease of releases